### PR TITLE
필요없는 alias 내용을 삭제한다.

### DIFF
--- a/FE/.babelrc
+++ b/FE/.babelrc
@@ -1,29 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": [
-    ["styled-components", { "ssr": true }],
-    [
-      "module-resolver",
-      {
-        "root": ["./src"],
-        "alias": {
-          "@atoms": "./components/atoms",
-          "@molecules": "./components/molecules",
-          "@organisms": "./components/organisms",
-          "@template": "./pages/template",
-          "@pages": "./pages",
-          "@assets": "./assets",
-          "@hooks": "./hooks",
-          "@mocks": "./mocks",
-          "@repository": "./repository",
-          "@routes": "./routes/",
-          "@store": "./store",
-          "@styles": "/styles",
-          "@utils": "./utils",
-          "@context": "./context",
-          "@parse": "./test"
-        }
-      }
-    ]
-  ]
+  "plugins": [["styled-components", { "ssr": true }]]
 }


### PR DESCRIPTION
next.config.js에서도 alias에 대한 내용을 설정하기 때문에 이곳에서는 굳이
중복으로 설정할 필요가 없는듯 싶습니다.